### PR TITLE
DNS-SD Client Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,11 @@ Doing a lookup for service providers is also very simple:
     // Make a channel for results and start listening
     entriesCh := make(chan *mdns.ServiceEntry, 4)
     go func() {
-        for entry := range entriesCh {
-            fmt.Printf("Got new entry: %v\n", entry)
-        }
+	for entry := range entriesCh {
+	    fmt.Printf("Got new entry: %v\n", entry)
+	}
     }()
 
     // Start the lookup
-    mdns.Lookup("_foobar._tcp", entriesCh)
+    mdns.ResolveService("_foobar._tcp.local.", entriesCh)
     close(entriesCh)
-

--- a/client.go
+++ b/client.go
@@ -307,21 +307,3 @@ func (c *client) recv(l *net.UDPConn, msgCh chan *dns.Msg) {
 		}
 	}
 }
-
-// ensureName is used to ensure the named node is in progress
-func ensureName(inprogress map[string]*ServiceEntry, name string) *ServiceEntry {
-	if inp, ok := inprogress[name]; ok {
-		return inp
-	}
-	inp := &ServiceEntry{
-		Name: name,
-	}
-	inprogress[name] = inp
-	return inp
-}
-
-// alias is used to setup an alias between two entries
-func alias(inprogress map[string]*ServiceEntry, src, dst string) {
-	srcEntry := ensureName(inprogress, src)
-	inprogress[dst] = srcEntry
-}

--- a/client.go
+++ b/client.go
@@ -186,6 +186,7 @@ func (c *client) broadcastAll() {
 				for idx, channel := range subscriberChans {
 					if channel == msg.Channel {
 						subscriberChans = append(subscriberChans[:idx],subscriberChans[idx + 1:]...)
+						close(channel)
 						break
 					}
 				}
@@ -277,7 +278,6 @@ func (c *client) Query(params *QueryParam) error {
 	select {
 	case <- time.After(params.Timeout):
 		c.Unsubscribe(answerChan)
-		close(answerChan)
 		return nil
 	}
 }

--- a/dnssd_client.go
+++ b/dnssd_client.go
@@ -1,0 +1,94 @@
+package mdns
+
+import (
+	"net"
+	"github.com/miekg/dns"
+	"fmt"
+	//"time"
+)
+
+// ServiceEntry is returned after we query for a service
+type ServiceEntry struct {
+	Name string
+	Addr net.IP
+	Port uint16
+	Info string
+
+	hasTXT bool
+	sent   bool
+}
+
+func findTXT(client *client, params *QueryParam, entries chan<- ServiceEntry, service ServiceEntry) {
+	//fmt.Println("TXT")
+	entries <- service
+}
+
+func findSRV(client *client, params *QueryParam, entries chan<- ServiceEntry, service ServiceEntry) {
+	seenList := map[string]bool{}
+	resultChannel := make(chan dns.RR)
+	params.Entries = resultChannel
+
+	go func() {
+		for result := range resultChannel {
+			if result, ok := result.(*dns.SRV); ok {
+				if !seenList[result.Target] {
+					seenList[result.Target] = true
+					//fmt.Println("SRV: " + result.Target)
+					newService := ServiceEntry{
+						Name: service.Name,
+						Port: result.Port,
+					}
+					newParams := DefaultParams(service.Name)
+					newParams.QueryType = dns.TypeTXT
+					findTXT(client, newParams, entries, newService)
+				}
+			}
+		}
+	}()
+
+	go client.Query(params)
+}
+
+
+
+
+func findPTR(client *client, params *QueryParam, entries chan<- ServiceEntry) {
+	seenList := map[string]bool{}
+	resultChannel := make(chan dns.RR)
+	params.Entries = resultChannel
+
+	go func() {
+		for result := range resultChannel {
+			if result, ok := result.(*dns.PTR); ok {
+				if !seenList[result.Ptr] {
+					seenList[result.Ptr] = true
+					service := ServiceEntry{
+						Name: result.Ptr,
+					}
+					//fmt.Println("PTR: " + result.Ptr)
+					params := DefaultParams(result.Ptr)
+					params.QueryType = dns.TypeSRV
+					findSRV(client, params, entries, service)
+				}
+			}
+		}
+	}()
+}
+
+func ResolveService(service string, entries chan<- ServiceEntry) error {
+	params := DefaultParams(service)
+	params.QueryType = dns.TypePTR
+
+	client, err := NewClient()
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+
+	findPTR(client, params, entries)
+	//processResultsSRV(client, resultCh, entries)
+
+
+	client.Query(params)
+	return nil
+}


### PR DESCRIPTION
Re-worked mdns client to cache all over the wire results, replay the cache for a new query, and provide additional RFC6763 data to lookups (eg parsing TXT records).  Additionally, mdns lookups can be made directly for a record (eg a SRV record) instead of only being able to resolve a service.
