### PR TITLE
Refactor mdns.MDNSService API in zone.go.

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -15,10 +15,7 @@ func TestServer_StartStop(t *testing.T) {
 }
 
 func TestServer_Lookup(t *testing.T) {
-	s := makeService(t)
-	s.Service = "_foobar._tcp"
-	s.Init()
-	serv, err := NewServer(&Config{Zone: s})
+	serv, err := NewServer(&Config{Zone: makeServiceWithServiceName(t, "_foobar._tcp")})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}


### PR DESCRIPTION
- Change API for constructing an MDNSService: use NewMDNSService func instead of
  creating an MDNSService struct and calling its Init method.
- Allow full specification of the host name and IP addresses of an MDNSService
  instead of relying on the net package to infer them from the OS.
- Remove deprecated Addr member of MDNSService.
- Modify tests to comply with new API.
