### PR TITLE
Make MDNSService respond to questions for A/AAAA records about its hostname.

### DIFF
--- a/zone.go
+++ b/zone.go
@@ -103,6 +103,11 @@ func (m *MDNSService) Records(q dns.Question) []dns.RR {
 		return m.serviceRecords(q)
 	case m.instanceAddr:
 		return m.instanceRecords(q)
+	case m.HostName:
+		if q.Qtype == dns.TypeA || q.Qtype == dns.TypeAAAA {
+			return m.instanceRecords(q)
+		}
+		fallthrough
 	default:
 		return nil
 	}

--- a/zone_test.go
+++ b/zone_test.go
@@ -178,3 +178,40 @@ func TestMDNSService_InstanceAddr_TXT(t *testing.T) {
 		t.Fatalf("bad: %v", recs[0])
 	}
 }
+
+func TestMDNSService_HostNameQuery(t *testing.T) {
+	s := makeService(t)
+	for _, test := range []struct {
+		q    dns.Question
+		want []dns.RR
+	}{
+		{
+			dns.Question{Name: "testhost.", Qtype: dns.TypeA},
+			[]dns.RR{&dns.A{
+				Hdr: dns.RR_Header{
+					Name:   "testhost.",
+					Rrtype: dns.TypeA,
+					Class:  dns.ClassINET,
+					Ttl:    10,
+				},
+				A: net.IP([]byte{192, 168, 0, 42}),
+			}},
+		},
+		{
+			dns.Question{Name: "testhost.", Qtype: dns.TypeAAAA},
+			[]dns.RR{&dns.AAAA{
+				Hdr: dns.RR_Header{
+					Name:   "testhost.",
+					Rrtype: dns.TypeAAAA,
+					Class:  dns.ClassINET,
+					Ttl:    10,
+				},
+				AAAA: net.ParseIP("2620:0:1000:1900:b0c2:d0b2:c411:18bc"),
+			}},
+		},
+	} {
+		if got := s.Records(test.q); !reflect.DeepEqual(got, test.want) {
+			t.Errorf("hostname query failed: s.Records(%v) = %v, want %v", test.q, got, test.want)
+		}
+	}
+}


### PR DESCRIPTION
- Adds a case in MDNSService.Records(q dns.Question) for A/AAAA questions for HostName
- Adds a test case to zone_test.go
