### PR TITLE
Use standard go.net (revert use of own branch)

### DIFF
--- a/client.go
+++ b/client.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hashicorp/go.net/ipv4"
-	"github.com/hashicorp/go.net/ipv6"
+	"code.google.com/p/go.net/ipv4"
+	"code.google.com/p/go.net/ipv6"
 	"github.com/miekg/dns"
 )
 


### PR DESCRIPTION
The issue that motivated that fork has been marked as fixed:
https://code.google.com/p/go/issues/detail?id=9047
