### PR TITLE
Fix double period at end of formatted hostname

### DIFF
--- a/zone.go
+++ b/zone.go
@@ -99,7 +99,7 @@ func NewMDNSService(instance, service, domain, hostName string, port int, ips []
 		if err != nil {
 			// Try appending the host domain suffix and lookup again
 			// (required for Linux-based hosts)
-			tmpHostName := fmt.Sprintf("%s%s.", hostName, domain)
+			tmpHostName := fmt.Sprintf("%s%s", hostName, domain)
 
 			ips, err = net.LookupIP(tmpHostName)
 


### PR DESCRIPTION
Since the domain is ensured to be fully qualified, adding a period will result in a domain like "machine.local..", which is incorrect.