### PR TITLE
use golang.org/x/net?

### DIFF
--- a/client.go
+++ b/client.go
@@ -8,9 +8,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hashicorp/go.net/ipv4"
-	"github.com/hashicorp/go.net/ipv6"
 	"github.com/miekg/dns"
+	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
 )
 
 // ServiceEntry is returned after we query for a service


### PR DESCRIPTION
Can you explain why you maintain a fork of the old `go.net` repo at hashicorp? I saw that it still imports code from `code.google.com`. 

```
github.com/hashicorp/go.net/ipv4/control_bsd.go:	"code.google.com/p/go.net/internal/iana"
github.com/hashicorp/go.net/ipv4/control_pktinfo.go:	"code.google.com/p/go.net/internal/iana"
github.com/hashicorp/go.net/ipv4/control_unix.go:	"code.google.com/p/go.net/internal/iana"
github.com/hashicorp/go.net/ipv4/example_test.go:	"code.google.com/p/go.net/internal/iana"
github.com/hashicorp/go.net/ipv4/multicast_test.go:	"code.google.com/p/go.net/internal/iana"
github.com/hashicorp/go.net/ipv4/sockopt_asmreq_unix.go:	"code.google.com/p/go.net/internal/iana"
github.com/hashicorp/go.net/ipv4/sockopt_asmreq_windows.go:	"code.google.com/p/go.net/internal/iana"
github.com/hashicorp/go.net/ipv4/sockopt_asmreqn_unix.go:	"code.google.com/p/go.net/internal/iana"
github.com/hashicorp/go.net/ipv4/sockopt_unix.go:	"code.google.com/p/go.net/internal/iana"
github.com/hashicorp/go.net/ipv4/sockopt_windows.go:	"code.google.com/p/go.net/internal/iana"
github.com/hashicorp/go.net/ipv4/unicast_test.go:	"code.google.com/p/go.net/internal/iana"
github.com/hashicorp/go.net/ipv4/unicastsockopt_test.go:	"code.google.com/p/go.net/internal/iana"
```

The [original](https://github.com/hashicorp/mdns/pull/23) [Issue](https://github.com/golang/go/issues/9047) for the fork is closed as far as I can tell.

Instead of updating the fork, I'd like to short circuit it here and just use the new upstream location of it.