### PR TITLE
Fix race condition on client and server shutdown

### DIFF
--- a/client.go
+++ b/client.go
@@ -102,7 +102,6 @@ type client struct {
 	ipv6MulticastConn *net.UDPConn
 
 	closed    bool
-	closedCh  chan struct{} // TODO(reddaly): This doesn't appear to be used.
 	closeLock sync.Mutex
 }
 
@@ -142,7 +141,6 @@ func newClient() (*client, error) {
 		ipv6MulticastConn: mconn6,
 		ipv4UnicastConn:   uconn4,
 		ipv6UnicastConn:   uconn6,
-		closedCh:          make(chan struct{}),
 	}
 	return c, nil
 }
@@ -158,7 +156,6 @@ func (c *client) Close() error {
 	c.closed = true
 
 	log.Printf("[INFO] mdns: Closing client %v", *c)
-	close(c.closedCh)
 
 	if c.ipv4UnicastConn != nil {
 		c.ipv4UnicastConn.Close()
@@ -343,7 +340,6 @@ func (c *client) recv(l *net.UDPConn, msgCh chan *dns.Msg) {
 		}
 		select {
 		case msgCh <- msg:
-		case <-c.closedCh:
 			return
 		}
 	}

--- a/client.go
+++ b/client.go
@@ -324,7 +324,13 @@ func (c *client) recv(l *net.UDPConn, msgCh chan *dns.Msg) {
 		return
 	}
 	buf := make([]byte, 65536)
-	for !c.closed {
+	for {
+		c.closeLock.Lock()
+		if c.closed {
+			c.closeLock.Unlock()
+			return
+		}
+		c.closeLock.Unlock()
 		n, err := l.Read(buf)
 		if err != nil {
 			log.Printf("[ERR] mdns: Failed to read packet: %v", err)

--- a/server.go
+++ b/server.go
@@ -107,7 +107,13 @@ func (s *Server) recv(c *net.UDPConn) {
 		return
 	}
 	buf := make([]byte, 65536)
-	for !s.shutdown {
+	for {
+		s.shutdownLock.Lock()
+		if s.shutdown {
+			s.shutdownLock.Unlock()
+			return
+		}
+		s.shutdownLock.Unlock()
 		n, from, err := c.ReadFrom(buf)
 		if err != nil {
 			continue

--- a/server.go
+++ b/server.go
@@ -48,7 +48,6 @@ type Server struct {
 	ipv6List *net.UDPConn
 
 	shutdown     bool
-	shutdownCh   chan struct{}
 	shutdownLock sync.Mutex
 }
 
@@ -64,10 +63,9 @@ func NewServer(config *Config) (*Server, error) {
 	}
 
 	s := &Server{
-		config:     config,
-		ipv4List:   ipv4List,
-		ipv6List:   ipv6List,
-		shutdownCh: make(chan struct{}),
+		config:   config,
+		ipv4List: ipv4List,
+		ipv6List: ipv6List,
 	}
 
 	if ipv4List != nil {
@@ -90,7 +88,6 @@ func (s *Server) Shutdown() error {
 		return nil
 	}
 	s.shutdown = true
-	close(s.shutdownCh)
 
 	if s.ipv4List != nil {
 		s.ipv4List.Close()


### PR DESCRIPTION
Fixes concurrent access to the shutdown flag on both client and server. Also removes the unused shutdown channels.

_Client_:

```
==================
WARNING: DATA RACE
Write by main goroutine:
  github.com/hashicorp/mdns.(*client).Close()
      /Users/asm/go/src/github.com/hashicorp/mdns/client.go:158 +0xd6
  github.com/hashicorp/mdns.Query()
      /Users/asm/go/src/github.com/hashicorp/mdns/client.go:85 +0x1cb
  main.client()
      /Users/asm/go/src/mdns-tester/main.go:27 +0x15b
  main.main()
      /Users/asm/go/src/mdns-tester/main.go:65 +0x1f0

Previous read by goroutine 8:
  github.com/hashicorp/mdns.(*client).recv()
      /Users/asm/go/src/github.com/hashicorp/mdns/client.go:327 +0xb9

Goroutine 8 (running) created at:
  github.com/hashicorp/mdns.(*client).query()
      /Users/asm/go/src/github.com/hashicorp/mdns/client.go:208 +0x341
  github.com/hashicorp/mdns.Query()
      /Users/asm/go/src/github.com/hashicorp/mdns/client.go:85 +0x1ac
  main.client()
      /Users/asm/go/src/mdns-tester/main.go:27 +0x15b
  main.main()
      /Users/asm/go/src/mdns-tester/main.go:65 +0x1f0
==================
Found 1 data race(s)
```

_Server_:

```
==================
WARNING: DATA RACE
Write by main goroutine:
  github.com/hashicorp/mdns.(*Server).Shutdown()
      /Users/asm/go/src/github.com/hashicorp/mdns/server.go:92 +0xd6
  main.server()
      /Users/asm/go/src/mdns-tester/main.go:54 +0x535
  main.main()
      /Users/asm/go/src/mdns-tester/main.go:67 +0x202

Previous read by goroutine 7:
  github.com/hashicorp/mdns.(*Server).recv()
      /Users/asm/go/src/github.com/hashicorp/mdns/server.go:110 +0xbc

Goroutine 7 (running) created at:
  github.com/hashicorp/mdns.NewServer()
      /Users/asm/go/src/github.com/hashicorp/mdns/server.go:74 +0x305
  main.server()
      /Users/asm/go/src/mdns-tester/main.go:42 +0x2a3
  main.main()
      /Users/asm/go/src/mdns-tester/main.go:67 +0x202
==================
Found 1 data race(s)
```
