### PR TITLE
Fix races in client and server

### DIFF
--- a/client.go
+++ b/client.go
@@ -8,9 +8,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hashicorp/go.net/ipv4"
-	"github.com/hashicorp/go.net/ipv6"
 	"github.com/miekg/dns"
+	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
 )
 
 // ServiceEntry is returned after we query for a service

--- a/client.go
+++ b/client.go
@@ -324,9 +324,15 @@ func (c *client) recv(l *net.UDPConn, msgCh chan *dns.Msg) {
 		return
 	}
 	buf := make([]byte, 65536)
-	c.closeLock.RLock()
-	defer c.closeLock.RUnlock()
-	for !c.closed {
+
+	var closed bool
+	for {
+		c.closeLock.RLock()
+		closed = c.closed
+		c.closeLock.RUnlock()
+		if closed {
+			break
+		}
 		n, err := l.Read(buf)
 		if err != nil {
 			log.Printf("[ERR] mdns: Failed to read packet: %v", err)

--- a/client.go
+++ b/client.go
@@ -103,7 +103,7 @@ type client struct {
 
 	closed    bool
 	closedCh  chan struct{} // TODO(reddaly): This doesn't appear to be used.
-	closeLock sync.Mutex
+	closeLock sync.RWMutex
 }
 
 // NewClient creates a new mdns Client that can be used to query
@@ -324,6 +324,8 @@ func (c *client) recv(l *net.UDPConn, msgCh chan *dns.Msg) {
 		return
 	}
 	buf := make([]byte, 65536)
+	c.closeLock.RLock()
+	defer c.closeLock.RUnlock()
 	for !c.closed {
 		n, err := l.Read(buf)
 		if err != nil {

--- a/server.go
+++ b/server.go
@@ -49,7 +49,7 @@ type Server struct {
 
 	shutdown     bool
 	shutdownCh   chan struct{}
-	shutdownLock sync.Mutex
+	shutdownLock sync.RWMutex
 }
 
 // NewServer is used to create a new mDNS server from a config
@@ -107,6 +107,8 @@ func (s *Server) recv(c *net.UDPConn) {
 		return
 	}
 	buf := make([]byte, 65536)
+	s.shutdownLock.RLock()
+	defer s.shutdownLock.RUnlock()
 	for !s.shutdown {
 		n, from, err := c.ReadFrom(buf)
 		if err != nil {

--- a/server.go
+++ b/server.go
@@ -107,9 +107,16 @@ func (s *Server) recv(c *net.UDPConn) {
 		return
 	}
 	buf := make([]byte, 65536)
+	var shutdown bool
 	s.shutdownLock.RLock()
 	defer s.shutdownLock.RUnlock()
-	for !s.shutdown {
+	for {
+		s.shutdownLock.RLock()
+		shutdown = s.shutdown
+		s.shutdownLock.RUnlock()
+		if shutdown {
+			break
+		}
 		n, from, err := c.ReadFrom(buf)
 		if err != nil {
 			continue


### PR DESCRIPTION
Fixes concurrent access to the shutdown flag on both client and server.

Client:

```
==================
WARNING: DATA RACE
Write by main goroutine:
  github.com/hashicorp/mdns.(*client).Close()
      /Users/asm/go/src/github.com/hashicorp/mdns/client.go:158 +0xd6
  github.com/hashicorp/mdns.Query()
      /Users/asm/go/src/github.com/hashicorp/mdns/client.go:85 +0x1cb
  main.client()
      /Users/asm/go/src/mdns-tester/main.go:27 +0x15b
  main.main()
      /Users/asm/go/src/mdns-tester/main.go:65 +0x1f0

Previous read by goroutine 8:
  github.com/hashicorp/mdns.(*client).recv()
      /Users/asm/go/src/github.com/hashicorp/mdns/client.go:327 +0xb9

Goroutine 8 (running) created at:
  github.com/hashicorp/mdns.(*client).query()
      /Users/asm/go/src/github.com/hashicorp/mdns/client.go:208 +0x341
  github.com/hashicorp/mdns.Query()
      /Users/asm/go/src/github.com/hashicorp/mdns/client.go:85 +0x1ac
  main.client()
      /Users/asm/go/src/mdns-tester/main.go:27 +0x15b
  main.main()
      /Users/asm/go/src/mdns-tester/main.go:65 +0x1f0
==================
Found 1 data race(s)
```

Server:

```
==================
WARNING: DATA RACE
Write by main goroutine:
  github.com/hashicorp/mdns.(*Server).Shutdown()
      /Users/asm/go/src/github.com/hashicorp/mdns/server.go:92 +0xd6
  main.server()
      /Users/asm/go/src/mdns-tester/main.go:54 +0x535
  main.main()
      /Users/asm/go/src/mdns-tester/main.go:67 +0x202

Previous read by goroutine 7:
  github.com/hashicorp/mdns.(*Server).recv()
      /Users/asm/go/src/github.com/hashicorp/mdns/server.go:110 +0xbc

Goroutine 7 (running) created at:
  github.com/hashicorp/mdns.NewServer()
      /Users/asm/go/src/github.com/hashicorp/mdns/server.go:74 +0x305
  main.server()
      /Users/asm/go/src/mdns-tester/main.go:42 +0x2a3
  main.main()
      /Users/asm/go/src/mdns-tester/main.go:67 +0x202
==================
Found 1 data race(s)
```
