### PR TITLE
Expose rr.Txt as []string instead of joining it with “|”.

### DIFF
--- a/client.go
+++ b/client.go
@@ -15,12 +15,13 @@ import (
 
 // ServiceEntry is returned after we query for a service
 type ServiceEntry struct {
-	Name   string
-	Host   string
-	AddrV4 net.IP
-	AddrV6 net.IP
-	Port   int
-	Info   string
+	Name       string
+	Host       string
+	AddrV4     net.IP
+	AddrV6     net.IP
+	Port       int
+	Info       string
+	InfoFields []string
 
 	Addr net.IP // @Deprecated
 
@@ -258,6 +259,7 @@ func (c *client) query(params *QueryParam) error {
 					// Pull out the txt
 					inp = ensureName(inprogress, rr.Hdr.Name)
 					inp.Info = strings.Join(rr.Txt, "|")
+					inp.InfoFields = rr.Txt
 					inp.hasTXT = true
 
 				case *dns.A:


### PR DESCRIPTION
Joining the different fields into a single string is problematic when
the fields contain the separator character “|” themselves.

As an example, I’ve named my chromecast “Hendrix|test”, and this happens
when I print a ServiceEntry:

ServiceEntry: &{Name:Hendrix|test._googlecast._tcp.local. Host:Hendrix|test.local. AddrV4:10.0.0.184 AddrV6:<nil> Port:8009 Info:id=3fc948dbfebcf5d7ec77d7b043dce81e|ve=04|md=Chromecast Audio|ic=/setup/icon.png|fn=Hendrix|test|ca=4|st=0|bs=FA8FCA928304|rs= Addr:10.0.0.184 hasTXT:true sent:true}

When using strings.Split, I would not correctly parse the fn= field.

With the new InfoFields member, this problem can be avoided entirely.