### PR TITLE
Fix possible IP comparison error

### DIFF
--- a/zone_test.go
+++ b/zone_test.go
@@ -196,7 +196,7 @@ func TestMDNSService_InstanceAddr_AAAA(t *testing.T) {
 	if got := len(ip6); got != net.IPv6len {
 		t.Fatalf("test IP failed to parse (len = %d, want %d)", got, net.IPv6len)
 	}
-	if !bytes.Equal(a4.AAAA, ip6) {
+	if !a4.AAAA.Equal(ip6) {
 		t.Fatalf("bad: %v", recs[0])
 	}
 }


### PR DESCRIPTION
A net.IP may be represented by both by a 4 as well as a 16 byte long byte slice. Because of this, it is not safe to compare IP addresses using bytes.Equal as the same IP address using a different internal representation will produce mismatches.

*Note, this PR was not initiated by my use of this package and noticing a bug, rather by creating an extension proposal for `go vet` and that signalling the possible misuse in this library.*

Cheers :)