### PR TITLE
Fix races found with go test -race

### DIFF
--- a/client.go
+++ b/client.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"net"
 	"strings"
-	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/miekg/dns"
@@ -102,9 +102,8 @@ type client struct {
 	ipv4MulticastConn *net.UDPConn
 	ipv6MulticastConn *net.UDPConn
 
-	closed    bool
-	closedCh  chan struct{} // TODO(reddaly): This doesn't appear to be used.
-	closeLock sync.Mutex
+	closed   int32
+	closedCh chan struct{} // TODO(reddaly): This doesn't appear to be used.
 }
 
 // NewClient creates a new mdns Client that can be used to query
@@ -150,13 +149,10 @@ func newClient() (*client, error) {
 
 // Close is used to cleanup the client
 func (c *client) Close() error {
-	c.closeLock.Lock()
-	defer c.closeLock.Unlock()
-
-	if c.closed {
+	if !atomic.CompareAndSwapInt32(&c.closed, 0, 1) {
+		// something else already closed it
 		return nil
 	}
-	c.closed = true
 
 	log.Printf("[INFO] mdns: Closing client %v", *c)
 	close(c.closedCh)
@@ -326,8 +322,13 @@ func (c *client) recv(l *net.UDPConn, msgCh chan *dns.Msg) {
 		return
 	}
 	buf := make([]byte, 65536)
-	for !c.closed {
+	for atomic.LoadInt32(&c.closed) == 0 {
 		n, err := l.Read(buf)
+
+		if atomic.LoadInt32(&c.closed) == 1 {
+			return
+		}
+
 		if err != nil {
 			log.Printf("[ERR] mdns: Failed to read packet: %v", err)
 			continue

--- a/server_test.go
+++ b/server_test.go
@@ -1,6 +1,7 @@
 package mdns
 
 import (
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -22,7 +23,7 @@ func TestServer_Lookup(t *testing.T) {
 	defer serv.Shutdown()
 
 	entries := make(chan *ServiceEntry, 1)
-	found := false
+	var found int32 = 0
 	go func() {
 		select {
 		case e := <-entries:
@@ -35,7 +36,7 @@ func TestServer_Lookup(t *testing.T) {
 			if e.Info != "Local web server" {
 				t.Fatalf("bad: %v", e)
 			}
-			found = true
+			atomic.StoreInt32(&found, 1)
 
 		case <-time.After(80 * time.Millisecond):
 			t.Fatalf("timeout")
@@ -52,7 +53,7 @@ func TestServer_Lookup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if !found {
+	if atomic.LoadInt32(&found) == 0 {
 		t.Fatalf("record not found")
 	}
 }


### PR DESCRIPTION
Basically the closed/shutdown bools on the client/server were being read without being locked.

I replaced the synchronization with atomic loads/cas ops on a int32 (int32 intstead of int64 to mitigate any potential alignment constraints when really we just need 1 bit)

Same thing is true with the server_test.go, bool being read and written simultaneously.