### PR TITLE
fix ipv6 sendto: no route to host

### DIFF
--- a/client.go
+++ b/client.go
@@ -133,6 +133,11 @@ func newClient() (*client, error) {
 		log.Printf("[ERR] mdns: Failed to bind to udp6 port: %v", err)
 	}
 
+	if uconn6 == nil || mconn6 == nil {
+		uconn6 = nil
+		mconn6 = nil
+	}
+
 	if mconn4 == nil && mconn6 == nil {
 		return nil, fmt.Errorf("failed to bind to any multicast udp port")
 	}


### PR DESCRIPTION
Failed to go test:
server_test.go:54: err: write udp6 [::]:49160->[ff02::fb]:5353: sendto: no route to host