### PR TITLE
QueryContext() for context cancellation support

### DIFF
--- a/client.go
+++ b/client.go
@@ -4,6 +4,7 @@
 package mdns
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net"
@@ -67,12 +68,30 @@ func DefaultParams(service string) *QueryParam {
 // to a channel. Sends will not block, so clients should make sure to
 // either read or buffer.
 func Query(params *QueryParam) error {
+	return QueryContext(context.Background(), params)
+}
+
+// QueryContext looks up a given service, in a domain, waiting at most
+// for a timeout before finishing the query. The results are streamed
+// to a channel. Sends will not block, so clients should make sure to
+// either read or buffer. QueryContext will attempt to stop the query
+// on cancellation.
+func QueryContext(ctx context.Context, params *QueryParam) error {
 	// Create a new client
 	client, err := newClient(!params.DisableIPv4, !params.DisableIPv6)
 	if err != nil {
 		return err
 	}
 	defer client.Close()
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			client.Close()
+		case <-client.closedCh:
+			return
+		}
+	}()
 
 	// Set the multicast interface
 	if params.Interface != nil {


### PR DESCRIPTION
This PR provides support client context cancellation by leveraging the existing unexported client.Close method.  A new QueryContext method is added to avoid breaking backwards compatibility with Query().