### PR TITLE
Prevent a nil pointer dereference segfault

### DIFF
--- a/client.go
+++ b/client.go
@@ -208,23 +208,31 @@ func (c *client) Close() error {
 // default if not provided
 func (c *client) setInterface(iface *net.Interface) error {
 	if c.use_ipv4 {
-		p := ipv4.NewPacketConn(c.ipv4UnicastConn)
-		if err := p.SetMulticastInterface(iface); err != nil {
-			return err
+		if c.ipv4UnicastConn != nil {
+			p := ipv4.NewPacketConn(c.ipv4UnicastConn)
+			if err := p.SetMulticastInterface(iface); err != nil {
+				return err
+			}
 		}
-		p = ipv4.NewPacketConn(c.ipv4MulticastConn)
-		if err := p.SetMulticastInterface(iface); err != nil {
-			return err
+		if c.ipv4MulticastConn != nil {
+			p := ipv4.NewPacketConn(c.ipv4MulticastConn)
+			if err := p.SetMulticastInterface(iface); err != nil {
+				return err
+			}
 		}
 	}
 	if c.use_ipv6 {
-		p2 := ipv6.NewPacketConn(c.ipv6UnicastConn)
-		if err := p2.SetMulticastInterface(iface); err != nil {
-			return err
+		if c.ipv6UnicastConn != nil {
+			p2 := ipv6.NewPacketConn(c.ipv6UnicastConn)
+			if err := p2.SetMulticastInterface(iface); err != nil {
+				return err
+			}
 		}
-		p2 = ipv6.NewPacketConn(c.ipv6MulticastConn)
-		if err := p2.SetMulticastInterface(iface); err != nil {
-			return err
+		if c.ipv6MulticastConn != nil {
+			p2 := ipv6.NewPacketConn(c.ipv6MulticastConn)
+			if err := p2.SetMulticastInterface(iface); err != nil {
+				return err
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
A nil pointer dereference segfault may occur when [ipv4, ipv6].NewPacketConn() is called with an argument that is nil. The four arguments to the four calls to NewPacketConn() may be nil if the functions that set them, inside the newClient() function, return a non-nil error. 

In newClient() there are two calls to net.ListenUDP that set uconn4 and uconn6, and two calls to net.ListenMulticastUDP that set mconn4 and mconn6. There are network scenarios where multicast may be allowed for IPv4 addresses, but not IPv6 addresses, for example. In this case the check in newClient() that returns an error, (if mconn4 == nil && mconn6 == nil), is not hit because only mconn6 is nil. Then, ipv6MulticastConn is set to nil in the returned client object. This nil value for ipv6MulticastConn is then used as an argument to ipv6.NewPacketConn in setInterface() and a nil pointer dereference segfault occurs. 

This PR prevents a segfault by only calling NewPacketConn if the argument to it is not nil.