### PR TITLE
Prevent a nil pointer dereference segfault

### DIFF
--- a/client.go
+++ b/client.go
@@ -188,13 +188,13 @@ func newClient(v4 bool, v6 bool) (*client, error) {
 	// Check that unicast and multicast connections have been made for IPv4 and IPv6
 	// and disable the respective protocol if not.
 	if uconn4 == nil || mconn4 == nil {
-		log.Printf("[ERR] mdns: Failed to listen to both unicast and multicast on IPv4")
+		logger.Printf("[INFO] mdns: Failed to listen to both unicast and multicast on IPv4")
 		uconn4 = nil
 		mconn4 = nil
 		v4 = false
 	}
 	if uconn6 == nil || mconn6 == nil {
-		log.Printf("[ERR] mdns: Failed to listen to both unicast and multicast on IPv6")
+		logger.Printf("[INFO] mdns: Failed to listen to both unicast and multicast on IPv6")
 		uconn6 = nil
 		mconn6 = nil
 		v6 = false

--- a/client.go
+++ b/client.go
@@ -151,24 +151,24 @@ func newClient(v4 bool, v6 bool) (*client, error) {
 	var mconn6 *net.UDPConn
 	var err error
 
+	// Establish unicast connections
 	if v4 {
 		uconn4, err = net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4zero, Port: 0})
 		if err != nil {
 			log.Printf("[ERR] mdns: Failed to bind to udp4 port: %v", err)
 		}
 	}
-
 	if v6 {
 		uconn6, err = net.ListenUDP("udp6", &net.UDPAddr{IP: net.IPv6zero, Port: 0})
 		if err != nil {
 			log.Printf("[ERR] mdns: Failed to bind to udp6 port: %v", err)
 		}
 	}
-
 	if uconn4 == nil && uconn6 == nil {
 		return nil, fmt.Errorf("failed to bind to any unicast udp port")
 	}
 
+	// Establish multicast connections
 	if v4 {
 		mconn4, err = net.ListenMulticastUDP("udp4", nil, ipv4Addr)
 		if err != nil {
@@ -181,9 +181,26 @@ func newClient(v4 bool, v6 bool) (*client, error) {
 			log.Printf("[ERR] mdns: Failed to bind to udp6 port: %v", err)
 		}
 	}
-
 	if mconn4 == nil && mconn6 == nil {
 		return nil, fmt.Errorf("failed to bind to any multicast udp port")
+	}
+
+	// Check that unicast and multicast connections have been made for IPv4 and IPv6
+	// and disable the respective protocol if not.
+	if uconn4 == nil || mconn4 == nil {
+		log.Printf("[ERR] mdns: Failed to listen to both unicast and multicast on IPv4")
+		uconn4 = nil
+		mconn4 = nil
+		v4 = false
+	}
+	if uconn6 == nil || mconn6 == nil {
+		log.Printf("[ERR] mdns: Failed to listen to both unicast and multicast on IPv6")
+		uconn6 = nil
+		mconn6 = nil
+		v6 = false
+	}
+	if !v4 && !v6 {
+		return nil, fmt.Errorf("at least one of IPv4 and IPv6 must be enabled for querying")
 	}
 
 	c := &client{


### PR DESCRIPTION
A nil pointer dereference segfault may occur when [ipv4, ipv6].NewPacketConn() is called with an argument that is nil. The four arguments to the four calls to NewPacketConn() may be nil if the functions that set them, inside the newClient() function, return a non-nil error.

In newClient() there are two calls to net.ListenUDP that set uconn4 and uconn6, and two calls to net.ListenMulticastUDP that set mconn4 and mconn6. There are network scenarios where multicast may be allowed for IPv4 addresses, but not IPv6 addresses, for example. In this case the check in newClient() that returns an error, (if mconn4 == nil && mconn6 == nil), is not hit because only mconn6 is nil. Then, ipv6MulticastConn is set to nil in the returned client object. This nil value for ipv6MulticastConn is then used as an argument to ipv6.NewPacketConn in setInterface() and a nil pointer dereference segfault occurs.

This PR prevents the segfault by checking that each protocol (IPv4 and IPv6) has both unicast and multicast connections. If either unicast or multicast is not present for a protocol, then both are disabled and the `use_ipv[4, 6]` flag is set to false.