### PR TITLE
require only ipv4 or ipv6 success for sendQuery success

### DIFF
--- a/client.go
+++ b/client.go
@@ -404,19 +404,24 @@ func (c *client) sendQuery(q *dns.Msg) error {
 	if err != nil {
 		return err
 	}
+	// success = true if msg is sent successfully, either by ipv4 or ipv6
+	success := false
 	if c.ipv4UnicastConn != nil {
 		_, err = c.ipv4UnicastConn.WriteToUDP(buf, ipv4Addr)
-		if err != nil {
-			return err
+		if err == nil {
+			success = true
 		}
 	}
 	if c.ipv6UnicastConn != nil {
 		_, err = c.ipv6UnicastConn.WriteToUDP(buf, ipv6Addr)
-		if err != nil {
-			return err
+		if err == nil {
+			success = true
 		}
 	}
-	return nil
+	if success {
+		return nil
+	}
+	return err
 }
 
 // recv is used to receive until we get a shutdown


### PR DESCRIPTION
serf's `TestCommandRun_mDNS` on my macOS M1 fails because `sendQuery` fails due to:
```go
    _, err = c.ipv6UnicastConn.WriteToUDP(buf, ipv6Addr)
```
this will fail because the ipv6 multicast connection doesn't bind to a specific interface.
```go
	ipv6List, _ := net.ListenMulticastUDP("udp6", config.Iface, ipv6Addr)
```
in this case `config.Iface` is nil.

however, this is successful
```go
	_, err = c.ipv4UnicastConn.WriteToUDP(buf, ipv4Addr)
```
even though `ipv4List` is created with `nil` iface. multicast works for ipv4 at `lo0` interface and it doesn't require specific interface binding.
`sendQuery` should be considered success with just one successful send. if it is successful on ipv4 but unsuccessful on ipv6, it's ok to proceed. if it is unsuccessful on ipv4 but successful on ipv6? that's unlikely, but still ok to proceed.