### PR TITLE
Clarify that a blocked channel will discard results

### DIFF
--- a/client.go
+++ b/client.go
@@ -65,19 +65,21 @@ func DefaultParams(service string) *QueryParam {
 	}
 }
 
-// Query looks up a given service, in a domain, waiting at most
-// for a timeout before finishing the query. The results are streamed
-// to a channel. Sends will not block, so clients should make sure to
-// either read or buffer.
+// Query looks up a given service, in a domain, waiting at most for
+// a timeout before finishing the query. The results are sent to the
+// params.Entries channel. If a result cannot be sent to params.Entries
+// immediately, it will be discarded. A large buffer on the channel can
+// ensure that no result is lost.
 func Query(params *QueryParam) error {
 	return QueryContext(context.Background(), params)
 }
 
 // QueryContext looks up a given service, in a domain, waiting at most
-// for a timeout before finishing the query. The results are streamed
-// to a channel. Sends will not block, so clients should make sure to
-// either read or buffer. QueryContext will attempt to stop the query
-// on cancellation.
+// for a timeout before finishing the query. The results are sent to the
+// params.Entries channel. If a result cannot be sent to params.Entries
+// immediately, it will be discarded. A large buffer on the channel can
+// ensure that no result is lost. QueryContext will attempt to stop the
+// query on cancellation.
 func QueryContext(ctx context.Context, params *QueryParam) error {
 	if params.Logger == nil {
 		params.Logger = log.Default()


### PR DESCRIPTION
I'd like to suggest a clarification in the documentation of the `Query` and `QueryContext` functions, because I had misunderstood it. Before this PR, the documentation of both functions stated the following:
> [...] The results are streamed to a channel. Sends will not block, so clients should make sure to either read or buffer.

When using the library, I made sure that the entries were indeed read from the channel in a timely manner, but some results were sporadically missing. After reading the code of the library, I realized that results are immediately discarded, if the receiving side is not quite as fast as the sending side. I think the documentation should put more emphasis on this behavior.
