### PR TITLE
client: filter mDNS query responses by queried service name

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014, 2025
+// Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MIT
 
 package mdns
@@ -316,6 +316,12 @@ func (c *client) query(params *QueryParam) error {
 	// Map the in-progress responses
 	inprogress := make(map[string]*ServiceEntry)
 
+	// Track names that belong to the queried service. Only entries
+	// reachable from a matching PTR record are processed; this
+	// prevents unrelated mDNS responses on the network from
+	// polluting the results.
+	validNames := make(map[string]bool)
+
 	// Listen until we reach the timeout
 	finish := time.After(params.Timeout)
 	for {
@@ -323,13 +329,21 @@ func (c *client) query(params *QueryParam) error {
 		case resp := <-msgCh:
 			var inp *ServiceEntry
 			for _, answer := range append(resp.msg.Answer, resp.msg.Extra...) {
-				// TODO(reddaly): Check that response corresponds to serviceAddr?
 				switch rr := answer.(type) {
 				case *dns.PTR:
-					// Create new entry for this
+					// Only accept PTR records for the service we queried.
+					if !strings.EqualFold(rr.Hdr.Name, serviceAddr) {
+						continue
+					}
+					validNames[rr.Ptr] = true
 					inp = ensureName(inprogress, rr.Ptr)
 
 				case *dns.SRV:
+					if !validNames[rr.Hdr.Name] {
+						continue
+					}
+					// The SRV target (hostname) is also valid for A/AAAA lookups
+					validNames[rr.Target] = true
 					// Check for a target mismatch
 					if rr.Target != rr.Hdr.Name {
 						alias(inprogress, rr.Hdr.Name, rr.Target)
@@ -341,6 +355,9 @@ func (c *client) query(params *QueryParam) error {
 					inp.Port = int(rr.Port)
 
 				case *dns.TXT:
+					if !validNames[rr.Hdr.Name] {
+						continue
+					}
 					// Pull out the txt
 					inp = ensureName(inprogress, rr.Hdr.Name)
 					inp.Info = strings.Join(rr.Txt, "|")
@@ -348,12 +365,18 @@ func (c *client) query(params *QueryParam) error {
 					inp.hasTXT = true
 
 				case *dns.A:
+					if !validNames[rr.Hdr.Name] {
+						continue
+					}
 					// Pull out the IP
 					inp = ensureName(inprogress, rr.Hdr.Name)
 					inp.Addr = rr.A // @Deprecated
 					inp.AddrV4 = rr.A
 
 				case *dns.AAAA:
+					if !validNames[rr.Hdr.Name] {
+						continue
+					}
 					// Pull out the IP
 					inp = ensureName(inprogress, rr.Hdr.Name)
 					inp.Addr = rr.AAAA   // @Deprecated


### PR DESCRIPTION
## Summary

The `query()` method in `client.go` processes all mDNS response records without validating whether they belong to the service being queried. On networks with many mDNS-enabled devices (smart speakers, streaming devices, etc.), unrelated multicast responses arrive during the query window and are blindly added to the results.

This causes callers like Consul's `retry_join` (via `go-discover`) to receive IP addresses of random network devices instead of actual service members, breaking cluster formation.

This resolves the `TODO(reddaly)` comment at the top of the response processing loop.

## Changes

Introduce a `validNames` map that gates processing of all record types:

- **PTR records**: only accepted if `rr.Hdr.Name` matches the queried `serviceAddr` (case-insensitive). The instance name (`rr.Ptr`) is added to `validNames`.
- **SRV records**: only processed if `rr.Hdr.Name` is in `validNames`. The SRV target hostname is also added to `validNames` so subsequent A/AAAA records for it are accepted.
- **TXT, A, AAAA records**: only processed if `rr.Hdr.Name` is in `validNames`.

## Testing

Tested on a home network with ~30 mDNS-enabled devices:

**Before (unpatched):**
```
Querying mDNS for _myservice._tcp (10s timeout)...
FOUND: mynode-1._myservice._tcp.local. 10.0.1.10:8301 ([])
FOUND: mynode-2._myservice._tcp.local. 10.0.2.10:8301 ([])
FOUND: device-A._spotify-connect._tcp.local. 10.0.1.50:35552 ([CPath=/zc/0 VERSION=1.0 Stack=SP])
FOUND: device-B._sleep-proxy._udp.local. 10.0.1.51:53482 ([])
FOUND: device-C._spotify-connect._tcp.local. 10.0.2.50:55853 ([CPath=/zc/0 VERSION=1.0 Stack=SP])
FOUND: device-D._googlecast._tcp.local. 10.0.2.51:1400 ([])
```

**After (patched):**
```
Querying mDNS for _myservice._tcp (10s timeout)...
FOUND: mynode-1._myservice._tcp.local. 10.0.1.10:8301 ([])
FOUND: mynode-2._myservice._tcp.local. 10.0.2.10:8301 ([])
```

Fixes #96