### PR TITLE
fix: merge address info when aliasing entries to handle out-of-order DNS records

### DIFF
--- a/client.go
+++ b/client.go
@@ -464,8 +464,22 @@ func ensureName(inprogress map[string]*ServiceEntry, name string) *ServiceEntry 
 	return inp
 }
 
-// alias is used to setup an alias between two entries
+// alias is used to setup an alias between two entries.
+// When the destination already has an entry (e.g. an A record arrived
+// before the SRV record), merge its address information into the source
+// entry so that nothing is lost.
 func alias(inprogress map[string]*ServiceEntry, src, dst string) {
 	srcEntry := ensureName(inprogress, src)
+	if dstEntry, ok := inprogress[dst]; ok && dstEntry != srcEntry {
+		// Merge address info from the existing destination entry
+		if srcEntry.AddrV4 == nil && dstEntry.AddrV4 != nil {
+			srcEntry.Addr = dstEntry.Addr
+			srcEntry.AddrV4 = dstEntry.AddrV4
+		}
+		if srcEntry.AddrV6IPAddr == nil && dstEntry.AddrV6IPAddr != nil {
+			srcEntry.AddrV6 = dstEntry.AddrV6
+			srcEntry.AddrV6IPAddr = dstEntry.AddrV6IPAddr
+		}
+	}
 	inprogress[dst] = srcEntry
 }


### PR DESCRIPTION
Fixes #145

## Problem

When DNS records arrive in certain orders (A/AAAA before SRV), the `alias` function overwrites an existing entry that already has an IP address with the SRV entry that only has port/host info. The IP address is lost, and the entry never becomes complete.

**Example failure sequence:**
1. PTR → creates entry
2. A record for `device.local.` → creates entry with IP
3. SRV for `device._service._tcp.local.` with target `device.local.` → `alias()` overwrites the A-record entry, losing the IP
4. Entry never completes because it has port but no IP

This was reported with Alfen EV Chargers but affects any device that sends A/AAAA records before SRV records.

## Fix

In `alias()`, when the destination key already has an entry with address information, merge the addresses into the source entry before overwriting the map entry.

## Testing

All existing tests pass.